### PR TITLE
added deprecation notice

### DIFF
--- a/position/src/main/java/org.avphs.position/org/avphs/position/PositionModule.java
+++ b/position/src/main/java/org.avphs.position/org/avphs/position/PositionModule.java
@@ -36,6 +36,7 @@ public class PositionModule implements CarModule {
         return 0;
     }
     
+    //DEPRECATED BECAUSE THIS EXISTS IN TRAKSIM
     public float getSpeed(){
         return 0;
     }


### PR DESCRIPTION
getSpeed() is a redundant function because it is in traksim (GetSpeed in DrDemo), it is now commented as deprecated